### PR TITLE
Fix embedding batcher tests per spec

### DIFF
--- a/app/core/performance_utils.py
+++ b/app/core/performance_utils.py
@@ -400,7 +400,8 @@ class EmbeddingBatcher:
             return cached_embedding
         
         # Use batch processor for uncached embeddings
-        result = await self._batch_processor.add_item(text)
+        future = await self._batch_processor.add_item(text)
+        result = await future
         return result
 
 


### PR DESCRIPTION
Fix `EmbeddingBatcher` tests and implementation to correctly handle async futures, mock the `encode` method, and prevent cache interference.

The `EmbeddingBatcher`'s `get_embedding` method was incorrectly awaiting the `add_item` call, which returns a `Future` object that then needed to be awaited itself. Additionally, tests were mocking the wrong embedder method (`aembed_documents` instead of `encode`), returning incorrect types, and suffering from cache pollution between runs. These changes ensure the tests accurately reflect the `EmbeddingBatcher`'s behavior and pass reliably.

---
<a href="https://cursor.com/background-agent?bcId=bc-30f50a43-0ebc-4fdf-8821-fc0b1c0d7bba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30f50a43-0ebc-4fdf-8821-fc0b1c0d7bba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

