### PR TITLE
Fix toolexecutor tests with spec

### DIFF
--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -18,18 +18,18 @@ from app.core.service_interface import ServiceStatus
 
 
 @pytest.fixture
-def mock_config():
-    """Mock configuration for testing"""
-    config = Mock()
-    return config
+def mock_config_service():
+    """Mock ConfigService for testing"""
+    config_service = Mock()
+    config_service.config = Mock()
+    return config_service
 
 
 @pytest.fixture
-async def tool_executor(mock_config):
+async def tool_executor(mock_config_service):
     """Create ToolExecutor instance"""
-    with patch('app.core.tool_executor.get_config', return_value=mock_config):
-        executor = ToolExecutor()
-        yield executor
+    executor = ToolExecutor(mock_config_service)
+    yield executor
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix `ToolExecutor` tests by correctly mocking `ConfigService` and passing it via dependency injection, resolving an `AttributeError` from patching a non-existent function.

The original tests attempted to patch `app.core.tool_executor.get_config`, which does not exist. The `ToolExecutor` class expects a `ConfigService` instance in its constructor (`__init__(self, config_service: ConfigService)`). This PR updates the test fixture to provide a mocked `ConfigService` directly to the `ToolExecutor` constructor, aligning with its actual dependency injection mechanism.

---
<a href="https://cursor.com/background-agent?bcId=bc-e069771d-3dc1-4f08-ac09-2cb4fd613204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e069771d-3dc1-4f08-ac09-2cb4fd613204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

