### PR TITLE
Fix toolregistry tests per spec

### DIFF
--- a/app/core/tool_registry.py
+++ b/app/core/tool_registry.py
@@ -304,18 +304,10 @@ tool_registry = ToolRegistry()
 
 
 # Middleware example: logging
-async def logging_middleware(tool_name: str) -> Callable[[Callable], Callable]:
+async def logging_middleware(tool_name: str, kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """Log all tool executions"""
-
-    def wrapper(func: Callable) -> Callable:
-        @wraps(func)
-        async def wrapped(*args, **kwargs):
-            logger.debug(f"Executing tool '{tool_name}' with args: {list(kwargs.keys())}")
-            return await func(*args, **kwargs)
-
-        return wrapped
-
-    return wrapper
+    logger.debug(f"Executing tool '{tool_name}' with args: {list(kwargs.keys())}")
+    return kwargs
 
 
 # Middleware example: parameter validation


### PR DESCRIPTION
Fix `ToolRegistry` tests and `logging_middleware` signature to match the current implementation.

The tests were failing due to several inconsistencies: they were calling a non-existent `register_tool()` method instead of using the decorator, using `get_schemas()` instead of `get_openai_schemas()`, and expecting `ToolNotFoundError` when `ValueError` was raised. The `logging_middleware` function also had an incorrect signature. This PR updates the tests to use the correct decorator pattern, matches method names, corrects expected error types, and fixes the middleware signature to ensure proper functionality and accurate testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bd4dce0-306d-4d05-8695-efc328633862">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bd4dce0-306d-4d05-8695-efc328633862">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

