### PR TITLE
Fix specific errors per spec

### DIFF
--- a/app/core/performance_utils.py
+++ b/app/core/performance_utils.py
@@ -167,15 +167,22 @@ class BatchProcessor:
         self._timer_task: Optional[asyncio.Task] = None
         self._running = False
         self._stop_event = asyncio.Event()
+        self._ready_event = asyncio.Event()
 
     async def start(self):
         """Start the batch processor"""
         self._running = True
         self._stop_event.clear()
+        self._ready_event.set()
+
+    async def wait_until_ready(self):
+        """Wait until the processor is ready to accept items"""
+        await self._ready_event.wait()
 
     async def stop(self):
         """Stop the batch processor and process any remaining items"""
         self._running = False
+        self._ready_event.clear()
         async with self._lock:
             if self._pending_items:
                 await self._process_batch()

--- a/tests/unit/test_performance_utils.py
+++ b/tests/unit/test_performance_utils.py
@@ -240,6 +240,7 @@ class TestBatchProcessor:
         
         # Start processor
         process_task = asyncio.create_task(processor.start())
+        await processor.wait_until_ready()
         
         try:
             # Add items to trigger batch
@@ -276,6 +277,7 @@ class TestBatchProcessor:
         
         # Start processor
         process_task = asyncio.create_task(processor.start())
+        await processor.wait_until_ready()
         
         try:
             # Add items (not enough to trigger by size)
@@ -309,6 +311,7 @@ class TestBatchProcessor:
         )
         
         process_task = asyncio.create_task(processor.start())
+        await processor.wait_until_ready()
         
         try:
             # Add items including error trigger
@@ -341,6 +344,7 @@ class TestBatchProcessor:
         )
         
         process_task = asyncio.create_task(processor.start())
+        await processor.wait_until_ready()
         
         # Add items (not enough to trigger)
         futures = []


### PR DESCRIPTION
Add `_ready_event` and `wait_until_ready` to `BatchProcessor` to fix a race condition in its startup sequence.

Previously, tests would create a task for `processor.start()` but immediately call `add_item()`, leading to a `RuntimeError` because the processor's `_running` flag wasn't set yet. This change introduces an explicit `_ready_event` that callers can await, ensuring the processor is fully initialized before use.

---
<a href="https://cursor.com/background-agent?bcId=bc-47cd46d5-4e84-457a-aaed-4b0344c8ba64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47cd46d5-4e84-457a-aaed-4b0344c8ba64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>